### PR TITLE
simple autofix for typescript-sort-keys/interface

### DIFF
--- a/lib/rules/interface.js
+++ b/lib/rules/interface.js
@@ -6,7 +6,7 @@ const { validOrders } = require('../utils/isValidOrders');
 module.exports = {
   meta: {
     type: 'suggestion',
-
+    fixable: 'code',
     docs: {
       description: 'require interface keys to be sorted',
       category: 'Stylistic Issues',
@@ -49,10 +49,11 @@ module.exports = {
     let stack = null;
 
     const visitor = node => {
-      const { prevName } = stack;
+      const { prevName, prevNode } = stack;
       const thisName = getPropertyName(node);
 
       stack.prevName = thisName || prevName;
+      stack.prevNode = node || prevNode;
 
       if (!prevName || !thisName) {
         return;
@@ -71,6 +72,15 @@ module.exports = {
             insensitive: insensitive ? 'insensitive ' : '',
             natural: natural ? 'natural ' : '',
           },
+          fix(fixer) {
+            const sourceCode = context.getSourceCode();
+            const thisText = sourceCode.getText(node);
+            const prevText = sourceCode.getText(prevNode);
+            return [
+              fixer.replaceText(node, prevText),
+              fixer.replaceText(prevNode, thisText),
+            ];
+          },
         });
       }
     };
@@ -80,6 +90,7 @@ module.exports = {
         stack = {
           upper: stack,
           prevName: null,
+          prevNode: null,
         };
       },
 
@@ -91,6 +102,7 @@ module.exports = {
         stack = {
           upper: stack,
           prevName: null,
+          prevNode: null,
         };
       },
 


### PR DESCRIPTION
approach from eslint-plugin-sort-keys-fix:
swap the pairs of entries that are found to be in the wrong order

... so result may still be only partially sorted, but running
autofix a couple of times is still easier than manually editing