### PR TITLE
Fixed react-native warning about package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "README.md"
   ],
   "exports": {
-    "import": "./lib/index.esm.js",
-    "require": "./lib/index.cjs.js",
-    "default": "./lib/index.cjs.js"
+    ".": {
+      "import": "./lib/index.esm.js",
+      "require": "./lib/index.cjs.js",
+      "default": "./lib/index.cjs.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "prepublishOnly": "yarn compile",


### PR DESCRIPTION
When running `react-native` under Node.js 14.x on a project that uses npm modules which specify the new exports field in `package.json`, `react-native` will print the following warning:

`warn Package uuid has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in /PATH_TO_CURRENT_PROJECT/node_modules/eslint-plugin-typescript-sort-keys/package.json`

The reason is that, starting in Node.js 14.x, as soon as an npm module defines the exports field in package.json, only the files listed there are exported. If package.json is not included in that list, it's no longer possible to do things like require.resolve('uuid/package.json');. 

So package.json should be defined in exports to be available for import.

This is linked to #27 

