### PR TITLE
Update package.json to support TypeScript 5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,10 +87,10 @@
   "peerDependencies": {
     "@typescript-eslint/parser": "^1 || ^2 || ^3 || ^4 || ^5",
     "eslint": "^5 || ^6 || ^7 || ^8",
-    "typescript": "^3 || ^4"
+    "typescript": "^3 || ^4 || ^5"
   },
   "engines": {
-    "node": "10 - 12 || >= 13.9"
+    "node": "12 || >= 13.9"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
Bump peerDependency typescript to support newly released TypeScript 5.0.

Pay attention, the minimum required node.js version is now set to 12, since TypeScript 5.0 itself only supports 12 and up.