### PR TITLE
Allow ``@typescript-eslint/parser@^7` as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "typescript": "5.1.6"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^6",
+    "@typescript-eslint/parser": "^6 || ^7",
     "eslint": "^7 || ^8",
     "typescript": "^3 || ^4 || ^5"
   },


### PR DESCRIPTION
This resolves #74 and #75