### PR TITLE
fix: change parser peerDep to >=6

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "typescript": "5.1.6"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^6 || ^7",
+    "@typescript-eslint/parser": ">=6",
     "eslint": "^7 || ^8",
     "typescript": "^3 || ^4 || ^5"
   },


### PR DESCRIPTION
eslint/parser is now up to version 8, and it seems likely that this plugin will continue working with future versions, so my proposal is just to make the peerDep >= 6.

Alternately, I'd be happy to change it to just add `|| ^8`

(I have done no testing to ensure that version 8 does not actually break anything)
